### PR TITLE
Add code coverage reporting with covr and codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,16 @@ before_install:
 
 install:
   - ./pkg-build.sh install_deps
+  - ./pkg-build.sh install_github jimhester/covr
 
 script:
   - ./pkg-build.sh run_tests
 
 after_failure:
   - ./pkg-build.sh dump_logs
+
+after_success:
+  - Rscript -e 'covr::codecov()'
 
 notifications:
   email:

--- a/inst/README.Rmd
+++ b/inst/README.Rmd
@@ -16,6 +16,7 @@ knitr::opts_chunk$set(
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/github/gaborcsardi/argufy?svg=true)](https://ci.appveyor.com/project/gaborcsardi/argufy)
 [![](http://www.r-pkg.org/badges/version/argufy)](http://www.r-pkg.org/pkg/argufy)
 [![CRAN RStudio mirror downloads](http://cranlogs.r-pkg.org/badges/argufy)](http://www.r-pkg.org/pkg/argufy)
+[![Coverage Status](https://img.shields.io/codecov/c/github/gaborcsardi/argufy/master.svg)](https://codecov.io/github/gaborcsardi/argufy?branch=master)
 
 
 Declare your functions with argument checks, and `argufy()` will generate

--- a/inst/README.md
+++ b/inst/README.md
@@ -9,6 +9,7 @@
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/github/gaborcsardi/argufy?svg=true)](https://ci.appveyor.com/project/gaborcsardi/argufy)
 [![](http://www.r-pkg.org/badges/version/argufy)](http://www.r-pkg.org/pkg/argufy)
 [![CRAN RStudio mirror downloads](http://cranlogs.r-pkg.org/badges/argufy)](http://www.r-pkg.org/pkg/argufy)
+[![Coverage Status](https://img.shields.io/codecov/c/github/gaborcsardi/argufy/master.svg)](https://codecov.io/github/gaborcsardi/argufy?branch=master)
 
 
 Declare your functions with argument checks, and `argufy()` will generate


### PR DESCRIPTION
This coverage is actually not quite accurate because it shows `argufy_package()` as being untested because it is only run in a different process (by disposables).

I will probably write some additional tests that would call `argufy_package()` directly on functions defined in an artificial environment so they would be covered.  (Should probably do that regardless of covr)
