### PR TITLE
WIP: Argufy Return

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -70,8 +70,7 @@ argufy <- function(fun, ...) {
   if (is.call(bod) && identical(bod[[1]], as.symbol("?"))) {
     check <- bod[[3]]
     body(fun) <-
-      substitute({
-        `_result_` <- `_val_`
+      substitute({ `_result_` <- local({`_val_`})
         stopifnot(`_check_`(`_result_`))
         `_result_`
       }, list(`_val_` = bod[[2]],

--- a/R/package.R
+++ b/R/package.R
@@ -65,16 +65,20 @@ argufy <- function(fun, ...) {
   ## Remove checks from the arguments
   formals(fun) <- remove_checks(fmls)
 
+  is_question <- function(x) is.call(x) && identical(x[[1]], as.symbol("?"))
+
   # if body ends with a call to `?`
   bod <- body(fun)
-  if (is.call(bod) && identical(bod[[1]], as.symbol("?"))) {
-    check <- bod[[3]]
+  if (is_question(bod)) {
+    if (is_question(bod[[2]])) {
+      bod[[2]] <- bod[[2]][[2]]
+    }
     body(fun) <-
       substitute({ `_result_` <- local({`_val_`})
         stopifnot(`_check_`(`_result_`))
         `_result_`
-      }, list(`_val_` = bod[[2]],
-              `_check_` = bod[[3]]))
+      }, list(`_val_` = bod[[3]],
+              `_check_` = bod[[2]]))
   }
 
   ## Add the checks to the body of the function

--- a/R/package.R
+++ b/R/package.R
@@ -65,6 +65,19 @@ argufy <- function(fun, ...) {
   ## Remove checks from the arguments
   formals(fun) <- remove_checks(fmls)
 
+  # if body ends with a call to `?`
+  bod <- body(fun)
+  if (is.call(bod) && identical(bod[[1]], as.symbol("?"))) {
+    check <- bod[[3]]
+    body(fun) <-
+      substitute({
+        `_result_` <- `_val_`
+        stopifnot(`_check_`(`_result_`))
+        `_result_`
+      }, list(`_val_` = bod[[2]],
+              `_check_` = bod[[3]]))
+  }
+
   ## Add the checks to the body of the function
   fun <- add_checks(fun, checks)
 


### PR DESCRIPTION
This works for the following functions using the trailing format.  It still needs to have the code cleaned up and made more readable, but thought I would show you the current state and see what you thought.

``` r
funs <- list(
  function(x) x ? is.numeric,
  function(x) { x } ? is.numeric,
  function(x) { return(x) } ? is.numeric,
  function(x) { if (x == "a") return(x) else 1 } ? is.numeric
)

sapply(funs, function(f) f(x = 1))
#> [1] 1 1 1 1

sapply(funs, function(f) f(x = "a"))
#> [1] "a" "a" "a" "a"

sapply(lapply(funs, argufy), function(f) try(f(x = 1)))
#> [1] 1 1 1 1

sapply(lapply(funs, argufy), function(f) try(f(x = "a")))
#> Error : is.numeric(`_result_`) is not TRUE
#> Error : is.numeric(`_result_`) is not TRUE
#> Error : is.numeric(`_result_`) is not TRUE
#> Error : is.numeric(`_result_`) is not TRUE

sapply(lapply(funs, argufy), function(f) print(f, useSource = FALSE))
#> function (x)
#> {
#>     `_result_` <- local({
#>         x
#>     })
#>     stopifnot(is.numeric(`_result_`))
#>     `_result_`
#> }
#> function (x)
#> {
#>     `_result_` <- local({
#>         {
#>             x
#>         }
#>     })
#>     stopifnot(is.numeric(`_result_`))
#>     `_result_`
#> }
#> function (x)
#> {
#>     `_result_` <- local({
#>         {
#>             return(x)
#>         }
#>     })
#>     stopifnot(is.numeric(`_result_`))
#>     `_result_`
#> }
#> function (x)
#> {
#>     `_result_` <- local({
#>         {
#>             if (x == "a")
#>                 return(x)
#>             else 1
#>         }
#>     })
#>     stopifnot(is.numeric(`_result_`))
#>     `_result_`
#> }
```
